### PR TITLE
Hitting back after expression is complete doesn't enable select input…

### DIFF
--- a/src/expressionBuilder.js
+++ b/src/expressionBuilder.js
@@ -1099,6 +1099,7 @@
       var $hiddenInput = this.s$('.exprInner input:not(:visible)').last();
       if ($hiddenInput && $hiddenInput.data('subExpr')) {
         $hiddenInput.data('subExpr').remove();
+        this.subExprSelect.select2('data', null).select2('enable', true).select2('open');
       }
       this.s$().trigger('eb-back');
     },


### PR DESCRIPTION
…. Fixed it

I noticed that hitting back button after expression is complete leaves the select input disabled. So this is what I added to my local copy. Just thought I would share this so that it will be helpful for others